### PR TITLE
Add JS Map support for encoding & decoding

### DIFF
--- a/src/Decoder.ts
+++ b/src/Decoder.ts
@@ -58,8 +58,9 @@ export type DecoderOptions<ContextType = undefined> = Readonly<
      * objects. Defaults to false.
      *
      * Besides the type of container, the main difference is that Map objects support a wider range
-     * of key types. Plain objects only support string keys, while Map objects support strings,
-     * numbers, bigints, and Uint8Arrays.
+     * of key types. Plain objects only support string keys (though you can enable
+     * `supportObjectNumberKeys` to coerce number keys to strings), while Map objects support
+     * strings, numbers, bigints, and Uint8Arrays.
      */
     useMap: boolean;
 

--- a/src/utils/typedArrays.ts
+++ b/src/utils/typedArrays.ts
@@ -19,3 +19,14 @@ export function createDataView(buffer: ArrayLike<number> | ArrayBufferView | Arr
   const bufferView = ensureUint8Array(buffer);
   return new DataView(bufferView.buffer, bufferView.byteOffset, bufferView.byteLength);
 }
+
+export function compareUint8Arrays(a: Uint8Array, b: Uint8Array): number {
+  const length = Math.min(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    const diff = a[i]! - b[i]!;
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return a.length - b.length;
+}

--- a/test/codec-bigint.test.ts
+++ b/test/codec-bigint.test.ts
@@ -253,24 +253,24 @@ describe("codec BigInt", () => {
       const encoded = encode(value, { extensionCodec });
       assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
     });
-  });
 
-  it("encodes and decodes 100n", () => {
-    const value = BigInt(100);
-    const encoded = encode(value, { extensionCodec });
-    assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
-  });
+    it("encodes and decodes 100n", () => {
+      const value = BigInt(100);
+      const encoded = encode(value, { extensionCodec });
+      assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+    });
 
-  it("encodes and decodes -100n", () => {
-    const value = BigInt(-100);
-    const encoded = encode(value, { extensionCodec });
-    assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
-  });
+    it("encodes and decodes -100n", () => {
+      const value = BigInt(-100);
+      const encoded = encode(value, { extensionCodec });
+      assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+    });
 
-  it("encodes and decodes MAX_SAFE_INTEGER+1", () => {
-    const value = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
-    const encoded = encode(value, { extensionCodec });
-    assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+    it("encodes and decodes MAX_SAFE_INTEGER+1", () => {
+      const value = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
+      const encoded = encode(value, { extensionCodec });
+      assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+    });
   });
 
   context("native", () => {

--- a/test/decode-map.test.ts
+++ b/test/decode-map.test.ts
@@ -1,0 +1,149 @@
+import assert from "assert";
+import { encode, decode, DecoderOptions, IntMode } from "../src";
+
+describe("decode with useMap specified", () => {
+  const options = { useMap: true } satisfies DecoderOptions;
+
+  it("decodes as Map with string keys", () => {
+    let actual = decode(encode({}), options);
+    let expected: Map<unknown, unknown> = new Map();
+    assert.deepStrictEqual(actual, expected);
+
+    actual = decode(encode({ a: 1 }), options);
+    expected = new Map([["a", 1]]);
+    assert.deepStrictEqual(actual, expected);
+
+    actual = decode(encode({ a: 1, b: { c: true } }), options);
+    expected = new Map<unknown, unknown>([
+      ["a", 1],
+      ["b", new Map([["c", true]])],
+    ]);
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("decodes as Map with binary keys", () => {
+    const input = new Map<Uint8Array, number>([
+      [Uint8Array.from([]), 0],
+      [Uint8Array.from([0, 1, 2, 3]), 1],
+      [Uint8Array.from([4, 5, 6, 7]), 2],
+    ]);
+    const actual = decode(encode(input), options);
+    assert.deepStrictEqual(actual, input);
+  });
+
+  it("decodes as Map with numeric keys", () => {
+    const input = new Map<number, number>([
+      [Number.MIN_SAFE_INTEGER, 1],
+      [-100, 2],
+      [-0.5, 3],
+      [0, 4],
+      [1, 5],
+      [2, 6],
+      [11.11, 7],
+      [Number.MAX_SAFE_INTEGER, 8],
+      [NaN, 9],
+    ]);
+    // TODO: test positive and negative infinity
+    const actual = decode(encode(input), options);
+    assert.deepStrictEqual(actual, input);
+  });
+
+  context("Numeric map keys with IntMode", () => {
+    const input = encode(
+      new Map<number | bigint, number>([
+        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), 0],
+        [Number.MIN_SAFE_INTEGER, 1],
+        [-100, 2],
+        [-0.5, 3],
+        [0, 4],
+        [1, 5],
+        [2, 6],
+        [11.11, 7],
+        [Number.MAX_SAFE_INTEGER, 8],
+        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), 9],
+        [NaN, 10],
+      ]),
+    );
+
+    it("decodes with IntMode.SAFE_NUMBER", () => {
+      assert.throws(
+        () => decode(input, { ...options, intMode: IntMode.SAFE_NUMBER }),
+        /Mode is IntMode\.SAFE_NUMBER and value is not a safe integer/,
+      );
+    });
+
+    it("decodes with IntMode.UNSAFE_NUMBER", () => {
+      const actual = decode(input, { ...options, intMode: IntMode.UNSAFE_NUMBER });
+      const expectedSubset = new Map<number, number>([
+        [Number.MIN_SAFE_INTEGER, 1],
+        [-100, 2],
+        [-0.5, 3],
+        [0, 4],
+        [1, 5],
+        [2, 6],
+        [11.11, 7],
+        [Number.MAX_SAFE_INTEGER, 8],
+        [NaN, 10],
+      ]);
+      assert.ok(actual instanceof Map);
+      assert.strictEqual(actual.size, expectedSubset.size + 2);
+      for (const [key, value] of expectedSubset) {
+        assert.deepStrictEqual(actual.get(key), value);
+      }
+    });
+
+    it("decodes with IntMode.MIXED", () => {
+      const actual = decode(input, { ...options, intMode: IntMode.MIXED });
+      const expected = new Map<number | bigint, number>([
+        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), 0],
+        [Number.MIN_SAFE_INTEGER, 1],
+        [-100, 2],
+        [-0.5, 3],
+        [0, 4],
+        [1, 5],
+        [2, 6],
+        [11.11, 7],
+        [Number.MAX_SAFE_INTEGER, 8],
+        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), 9],
+        [NaN, 10],
+      ]);
+      assert.deepStrictEqual(actual, expected);
+    });
+
+    it("decodes with IntMode.BIGINT", () => {
+      const actual = decode(input, { ...options, intMode: IntMode.BIGINT });
+      const expected = new Map<number | bigint, bigint>([
+        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), BigInt(0)],
+        [BigInt(Number.MIN_SAFE_INTEGER), BigInt(1)],
+        [BigInt(-100), BigInt(2)],
+        [-0.5, BigInt(3)],
+        [BigInt(0), BigInt(4)],
+        [BigInt(1), BigInt(5)],
+        [BigInt(2), BigInt(6)],
+        [11.11, BigInt(7)],
+        [BigInt(Number.MAX_SAFE_INTEGER), BigInt(8)],
+        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), BigInt(9)],
+        [NaN, BigInt(10)],
+      ]);
+      assert.deepStrictEqual(actual, expected);
+    });
+
+    it("decodes with IntMode.AS_ENCODED", () => {
+      const actual = decode(input, { ...options, intMode: IntMode.AS_ENCODED });
+      const expected = new Map<number | bigint, number>([
+        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), 0],
+        [BigInt(Number.MIN_SAFE_INTEGER), 1],
+        [-100, 2],
+        [-0.5, 3],
+        [0, 4],
+        [1, 5],
+        [2, 6],
+        [11.11, 7],
+        [BigInt(Number.MAX_SAFE_INTEGER), 8],
+        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), 9],
+        [NaN, 10],
+      ]);
+      assert.deepStrictEqual(actual, expected);
+    });
+  });
+});

--- a/test/decode-map.test.ts
+++ b/test/decode-map.test.ts
@@ -33,6 +33,7 @@ describe("decode with useMap specified", () => {
 
   it("decodes as Map with numeric keys", () => {
     const input = new Map<number, number>([
+      [Number.NEGATIVE_INFINITY, 0],
       [Number.MIN_SAFE_INTEGER, 1],
       [-100, 2],
       [-0.5, 3],
@@ -41,9 +42,9 @@ describe("decode with useMap specified", () => {
       [2, 6],
       [11.11, 7],
       [Number.MAX_SAFE_INTEGER, 8],
-      [NaN, 9],
+      [Number.POSITIVE_INFINITY, 9],
+      [NaN, 10],
     ]);
-    // TODO: test positive and negative infinity
     const actual = decode(encode(input), options);
     assert.deepStrictEqual(actual, input);
   });
@@ -51,17 +52,19 @@ describe("decode with useMap specified", () => {
   context("Numeric map keys with IntMode", () => {
     const input = encode(
       new Map<number | bigint, number>([
-        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), 0],
-        [Number.MIN_SAFE_INTEGER, 1],
-        [-100, 2],
-        [-0.5, 3],
-        [0, 4],
-        [1, 5],
-        [2, 6],
-        [11.11, 7],
-        [Number.MAX_SAFE_INTEGER, 8],
-        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), 9],
-        [NaN, 10],
+        [Number.NEGATIVE_INFINITY, 0],
+        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), 1],
+        [Number.MIN_SAFE_INTEGER, 2],
+        [-100, 3],
+        [-0.5, 4],
+        [0, 5],
+        [1, 6],
+        [2, 7],
+        [11.11, 8],
+        [Number.MAX_SAFE_INTEGER, 9],
+        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), 10],
+        [Number.POSITIVE_INFINITY, 11],
+        [NaN, 12],
       ]),
     );
 
@@ -74,16 +77,19 @@ describe("decode with useMap specified", () => {
 
     it("decodes with IntMode.UNSAFE_NUMBER", () => {
       const actual = decode(input, { ...options, intMode: IntMode.UNSAFE_NUMBER });
+      // Omit integers that exceed the safe range
       const expectedSubset = new Map<number, number>([
-        [Number.MIN_SAFE_INTEGER, 1],
-        [-100, 2],
-        [-0.5, 3],
-        [0, 4],
-        [1, 5],
-        [2, 6],
-        [11.11, 7],
-        [Number.MAX_SAFE_INTEGER, 8],
-        [NaN, 10],
+        [Number.NEGATIVE_INFINITY, 0],
+        [Number.MIN_SAFE_INTEGER, 2],
+        [-100, 3],
+        [-0.5, 4],
+        [0, 5],
+        [1, 6],
+        [2, 7],
+        [11.11, 8],
+        [Number.MAX_SAFE_INTEGER, 9],
+        [Number.POSITIVE_INFINITY, 11],
+        [NaN, 12],
       ]);
       assert.ok(actual instanceof Map);
       assert.strictEqual(actual.size, expectedSubset.size + 2);
@@ -95,17 +101,19 @@ describe("decode with useMap specified", () => {
     it("decodes with IntMode.MIXED", () => {
       const actual = decode(input, { ...options, intMode: IntMode.MIXED });
       const expected = new Map<number | bigint, number>([
-        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), 0],
-        [Number.MIN_SAFE_INTEGER, 1],
-        [-100, 2],
-        [-0.5, 3],
-        [0, 4],
-        [1, 5],
-        [2, 6],
-        [11.11, 7],
-        [Number.MAX_SAFE_INTEGER, 8],
-        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), 9],
-        [NaN, 10],
+        [Number.NEGATIVE_INFINITY, 0],
+        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), 1],
+        [Number.MIN_SAFE_INTEGER, 2],
+        [-100, 3],
+        [-0.5, 4],
+        [0, 5],
+        [1, 6],
+        [2, 7],
+        [11.11, 8],
+        [Number.MAX_SAFE_INTEGER, 9],
+        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), 10],
+        [Number.POSITIVE_INFINITY, 11],
+        [NaN, 12],
       ]);
       assert.deepStrictEqual(actual, expected);
     });
@@ -113,17 +121,19 @@ describe("decode with useMap specified", () => {
     it("decodes with IntMode.BIGINT", () => {
       const actual = decode(input, { ...options, intMode: IntMode.BIGINT });
       const expected = new Map<number | bigint, bigint>([
-        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), BigInt(0)],
-        [BigInt(Number.MIN_SAFE_INTEGER), BigInt(1)],
-        [BigInt(-100), BigInt(2)],
-        [-0.5, BigInt(3)],
-        [BigInt(0), BigInt(4)],
-        [BigInt(1), BigInt(5)],
-        [BigInt(2), BigInt(6)],
-        [11.11, BigInt(7)],
-        [BigInt(Number.MAX_SAFE_INTEGER), BigInt(8)],
-        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), BigInt(9)],
-        [NaN, BigInt(10)],
+        [Number.NEGATIVE_INFINITY, BigInt(0)],
+        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), BigInt(1)],
+        [BigInt(Number.MIN_SAFE_INTEGER), BigInt(2)],
+        [BigInt(-100), BigInt(3)],
+        [-0.5, BigInt(4)],
+        [BigInt(0), BigInt(5)],
+        [BigInt(1), BigInt(6)],
+        [BigInt(2), BigInt(7)],
+        [11.11, BigInt(8)],
+        [BigInt(Number.MAX_SAFE_INTEGER), BigInt(9)],
+        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), BigInt(10)],
+        [Number.POSITIVE_INFINITY, BigInt(11)],
+        [NaN, BigInt(12)],
       ]);
       assert.deepStrictEqual(actual, expected);
     });
@@ -131,17 +141,19 @@ describe("decode with useMap specified", () => {
     it("decodes with IntMode.AS_ENCODED", () => {
       const actual = decode(input, { ...options, intMode: IntMode.AS_ENCODED });
       const expected = new Map<number | bigint, number>([
-        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), 0],
-        [BigInt(Number.MIN_SAFE_INTEGER), 1],
-        [-100, 2],
-        [-0.5, 3],
-        [0, 4],
-        [1, 5],
-        [2, 6],
-        [11.11, 7],
-        [BigInt(Number.MAX_SAFE_INTEGER), 8],
-        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), 9],
-        [NaN, 10],
+        [Number.NEGATIVE_INFINITY, 0],
+        [BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1), 1],
+        [BigInt(Number.MIN_SAFE_INTEGER), 2],
+        [-100, 3],
+        [-0.5, 4],
+        [0, 5],
+        [1, 6],
+        [2, 7],
+        [11.11, 8],
+        [BigInt(Number.MAX_SAFE_INTEGER), 9],
+        [BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1), 10],
+        [Number.POSITIVE_INFINITY, 11],
+        [NaN, 12],
       ]);
       assert.deepStrictEqual(actual, expected);
     });

--- a/test/decode-raw-strings.test.ts
+++ b/test/decode-raw-strings.test.ts
@@ -2,16 +2,16 @@ import assert from "assert";
 import { encode, decode } from "../src";
 import type { DecoderOptions } from "../src";
 
-describe("decode with useRawBinaryStrings specified", () => {
-  const options = { useRawBinaryStrings: true } satisfies DecoderOptions;
+describe("decode with rawBinaryStringValues specified", () => {
+  const options = { rawBinaryStringValues: true } satisfies DecoderOptions;
 
-  it("decodes string as binary", () => {
+  it("decodes string values as binary", () => {
     const actual = decode(encode("foo"), options);
     const expected = Uint8Array.from([0x66, 0x6f, 0x6f]);
     assert.deepStrictEqual(actual, expected);
   });
 
-  it("decodes invalid UTF-8 string as binary", () => {
+  it("decodes invalid UTF-8 string values as binary", () => {
     const invalidUtf8String = Uint8Array.from([
       61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50, 176,
       184, 221, 66, 188, 171, 36, 135, 121,
@@ -25,15 +25,9 @@ describe("decode with useRawBinaryStrings specified", () => {
     assert.deepStrictEqual(actual, invalidUtf8String);
   });
 
-  it("decodes object keys as strings", () => {
+  it("decodes map string keys as strings", () => {
     const actual = decode(encode({ key: "foo" }), options);
     const expected = { key: Uint8Array.from([0x66, 0x6f, 0x6f]) };
-    assert.deepStrictEqual(actual, expected);
-  });
-
-  it("decodes map keys as binary when useMap is enabled", () => {
-    const actual = decode(encode({ key: "foo" }), { ...options, useMap: true });
-    const expected = new Map([[Uint8Array.from([0x6b, 0x65, 0x79]), Uint8Array.from([0x66, 0x6f, 0x6f])]]);
     assert.deepStrictEqual(actual, expected);
   });
 
@@ -51,5 +45,88 @@ describe("decode with useRawBinaryStrings specified", () => {
     assert.throws(() => {
       decode(encode("foo"), lengthLimitedOptions);
     }, /max length exceeded/i);
+  });
+});
+
+describe("decode with rawBinaryStringKeys specified", () => {
+  const options = { rawBinaryStringKeys: true, useMap: true } satisfies DecoderOptions;
+
+  it("errors if useMap is not enabled", () => {
+    assert.throws(() => {
+      decode(encode({ key: "foo" }), { rawBinaryStringKeys: true });
+    }, new Error("rawBinaryStringKeys is only supported when useMap is true"));
+  });
+
+  it("decodes map string keys as binary", () => {
+    const actual = decode(encode({ key: "foo" }), options);
+    const expected = new Map([[Uint8Array.from([0x6b, 0x65, 0x79]), "foo"]]);
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("decodes invalid UTF-8 string keys as binary", () => {
+    const invalidUtf8String = Uint8Array.from([
+      61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50, 176,
+      184, 221, 66, 188, 171, 36, 135, 121,
+    ]);
+    const encodedMap = Uint8Array.from([
+      129, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247,
+      19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121, 163, 97, 98, 99,
+    ]);
+    const actual = decode(encodedMap, options);
+    const expected = new Map([[invalidUtf8String, "abc"]]);
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("decodes string values as strings", () => {
+    const actual = decode(encode("foo"), options);
+    const expected = "foo";
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("ignores maxStrLength", () => {
+    const lengthLimitedOptions = { ...options, maxStrLength: 1 } satisfies DecoderOptions;
+
+    const actual = decode(encode({ foo: 1 }), lengthLimitedOptions);
+    const expected = new Map([[Uint8Array.from([0x66, 0x6f, 0x6f]), 1]]);
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("respects maxBinLength", () => {
+    const lengthLimitedOptions = { ...options, maxBinLength: 1 } satisfies DecoderOptions;
+
+    assert.throws(() => {
+      decode(encode({ foo: 1 }), lengthLimitedOptions);
+    }, /max length exceeded/i);
+  });
+});
+
+describe("decode with rawBinaryStringKeys and rawBinaryStringValues", () => {
+  const options = { rawBinaryStringValues: true, rawBinaryStringKeys: true, useMap: true } satisfies DecoderOptions;
+
+  it("errors if useMap is not enabled", () => {
+    assert.throws(() => {
+      decode(encode({ key: "foo" }), { rawBinaryStringKeys: true, rawBinaryStringValues: true });
+    }, new Error("rawBinaryStringKeys is only supported when useMap is true"));
+  });
+
+  it("decodes map string keys and values as binary", () => {
+    const actual = decode(encode({ key: "foo" }), options);
+    const expected = new Map([[Uint8Array.from([0x6b, 0x65, 0x79]), Uint8Array.from([0x66, 0x6f, 0x6f])]]);
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("decodes invalid UTF-8 string keys and values as binary", () => {
+    const invalidUtf8String = Uint8Array.from([
+      61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50, 176,
+      184, 221, 66, 188, 171, 36, 135, 121,
+    ]);
+    const encodedMap = Uint8Array.from([
+      129, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247,
+      19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84,
+      121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121,
+    ]);
+    const actual = decode(encodedMap, options);
+    const expected = new Map([[invalidUtf8String, invalidUtf8String]]);
+    assert.deepStrictEqual(actual, expected);
   });
 });

--- a/test/decode-raw-strings.test.ts
+++ b/test/decode-raw-strings.test.ts
@@ -31,6 +31,12 @@ describe("decode with useRawBinaryStrings specified", () => {
     assert.deepStrictEqual(actual, expected);
   });
 
+  it("decodes map keys as binary when useMap is enabled", () => {
+    const actual = decode(encode({ key: "foo" }), { ...options, useMap: true });
+    const expected = new Map([[Uint8Array.from([0x6b, 0x65, 0x79]), Uint8Array.from([0x66, 0x6f, 0x6f])]]);
+    assert.deepStrictEqual(actual, expected);
+  });
+
   it("ignores maxStrLength", () => {
     const lengthLimitedOptions = { ...options, maxStrLength: 1 } satisfies DecoderOptions;
 

--- a/test/prototype-pollution.test.ts
+++ b/test/prototype-pollution.test.ts
@@ -1,22 +1,31 @@
-import { throws } from "assert";
+import { throws, deepStrictEqual } from "assert";
 import { encode, decode, DecodeError } from "@msgpack/msgpack";
 
 describe("prototype pollution", () => {
   context("__proto__ exists as a map key", () => {
-    it("raises DecodeError in decoding", () => {
-      const o = {
-        foo: "bar",
-      };
-      // override __proto__ as an enumerable property
-      Object.defineProperty(o, "__proto__", {
-        value: new Date(0),
-        enumerable: true,
-      });
-      const encoded = encode(o);
+    const o = {
+      foo: "bar",
+    };
+    // override __proto__ as an enumerable property
+    Object.defineProperty(o, "__proto__", {
+      value: new Date(0),
+      enumerable: true,
+    });
+    const encoded = encode(o);
 
+    it("raises DecodeError in decoding", () => {
       throws(() => {
         decode(encoded);
-      }, DecodeError);
+      }, new DecodeError("The key __proto__ is not allowed"));
+    });
+
+    it("succeeds with useMap enabled", () => {
+      const decoded = decode(encoded, { useMap: true });
+      const expected = new Map<string, unknown>([
+        ["foo", "bar"],
+        ["__proto__", new Date(0)],
+      ]);
+      deepStrictEqual(decoded, expected);
     });
   });
 });


### PR DESCRIPTION
Adds support for encoding and decoding [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) objects, as an alternative to plain javascript objects.

The primary advantage is that this adds much better non-string type support for map keys.