### PR TITLE
Add ability to encode raw binary strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ NodeJS `Buffer` is also acceptable because it is a subclass of `Uint8Array`.
 | intMode                 | IntMode        | `IntMode.AS_ENCODED` if `useBigInt64` is `true` or `IntMode.UNSAFE_NUMBER` otherwise |
 | rawBinaryStringKeys     | boolean        | false                                                                                |
 | rawBinaryStringValues   | boolean        | false                                                                                |
+| useRawBinaryStringClass | boolean        | false                                                                                |
 | useMap                  | boolean        | false                                                                                |
 | supportObjectNumberKeys | boolean        | false                                                                                |
 | maxStrLength            | number         | `4_294_967_295` (UINT32_MAX)                                                         |
@@ -174,7 +175,7 @@ You can use `max${Type}Length` to limit the length of each type decoded.
 
 `intMode` determines whether decoded integers should be returned as numbers or bigints in different circumstances. The possible values are [described below](#intmode).
 
-To skip UTF-8 decoding of strings, one or both of `rawBinaryStringKeys` and `rawBinaryStringValues` can be set to `true`. If enabled, strings are decoded into `Uint8Array`. `rawBinaryStringKeys` affects only map keys, while `rawBinaryStringValues` affect all other string values.
+To skip UTF-8 decoding of strings, one or both of `rawBinaryStringKeys` and `rawBinaryStringValues` can be set to `true`. If enabled, strings are decoded into `Uint8Array`, or a `RawBinaryString` which wraps a `Uint8Array` if `useRawBinaryStringClass` is true. `rawBinaryStringKeys` affects only map keys, while `rawBinaryStringValues` affect all other string values. You may want to enable `useRawBinaryStringClass` if you want to distinguish between regular strings and binary strings, or if you wish to re-encode the object, since `RawBinaryString` instances will be encoded as regular strings.
 
 If `useMap` is enabled, maps are decoded into the `Map` container instead of plain objects. `Map` objects support a wider range of key types. Plain objects only support string keys (though you can enable `supportObjectNumberKeys` to coerce number keys to strings), while `Map` objects support strings, numbers, bigints, and Uint8Arrays.
 
@@ -549,7 +550,7 @@ The mapping of integers varies on the setting of `intMode`.
 
 - \*1 Both `null` and `undefined` are mapped to `nil` (`0xC0`) type, and are decoded into `null`
 - \*2 MessagePack ints are decoded as either numbers or bigints depending on the [IntMode](#intmode) used during decoding.
-- \*3 If you'd like to skip UTF-8 decoding of strings, enable one of `rawBinaryStringKeys` or `rawBinaryStringValues`. In that case, strings are decoded into `Uint8Array`.
+- \*3 If you'd like to skip UTF-8 decoding of strings, enable one of `rawBinaryStringKeys` or `rawBinaryStringValues`. In that case, strings are decoded into a `Uint8Array` or a `RawBinaryString`, depending on the value of `useRawBinaryStringClass`.
 - \*4 Any `ArrayBufferView`s including NodeJS's `Buffer` are mapped to `bin` family, and are decoded into `Uint8Array`
 - \*5 In handling `Object`, it is regarded as `Record<string, unknown>` in terms of TypeScript
 - \*6 MessagePack timestamps may have nanoseconds, which will lost when it is decoded into JavaScript `Date`. This behavior can be overridden by registering `-1` for the extension codec.

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -406,6 +406,7 @@ export class Encoder<ContextType = undefined> {
   private sortMapKeys(keys: Array<unknown>): Array<unknown> {
     const numericKeys: Array<number | bigint> = [];
     const stringKeys: Array<string> = [];
+    const rawStringKeys: Array<RawBinaryString> = [];
     const binaryKeys: Array<Uint8Array> = [];
     for (const key of keys) {
       if (typeof key === "number") {
@@ -419,15 +420,20 @@ export class Encoder<ContextType = undefined> {
         stringKeys.push(key);
       } else if (ArrayBuffer.isView(key)) {
         binaryKeys.push(ensureUint8Array(key));
+      } else if (key instanceof RawBinaryString) {
+        rawStringKeys.push(key);
       } else {
         throw new Error(`Unsupported map key type: ${Object.prototype.toString.apply(key)}`);
       }
     }
     numericKeys.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)); // Avoid using === to compare numbers and bigints
     stringKeys.sort();
+    rawStringKeys.sort((a, b) =>
+      compareUint8Arrays(ensureUint8Array(a.rawBinaryValue), ensureUint8Array(b.rawBinaryValue)),
+    );
     binaryKeys.sort(compareUint8Arrays);
-    // At the moment this arbitrarily orders the keys as numeric, string, binary
-    return ([] as Array<unknown>).concat(numericKeys, stringKeys, binaryKeys);
+    // At the moment this arbitrarily orders the keys as numeric, string, raw string, binary
+    return ([] as Array<unknown>).concat(numericKeys, stringKeys, rawStringKeys, binaryKeys);
   }
 
   private encodeMapObject(object: Record<string, unknown>, depth: number) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ import { Encoder } from "./Encoder";
 export { Encoder };
 import type { EncoderOptions } from "./Encoder";
 export type { EncoderOptions };
+import { RawBinaryString } from "./utils/typedArrays";
+export { RawBinaryString };
 
 // Utilities for Extension Types:
 

--- a/src/utils/typedArrays.ts
+++ b/src/utils/typedArrays.ts
@@ -30,3 +30,22 @@ export function compareUint8Arrays(a: Uint8Array, b: Uint8Array): number {
   }
   return a.length - b.length;
 }
+
+/**
+ * Represents a binary value that should be encoded as if it were a string.
+ *
+ * Effectively, this is a string that has already been UTF-8 encoded to a binary string. This is
+ * useful if you need to encode a value as a string, but that value contains invalid UTF-8 sequences;
+ * ideally this situation should be avoided and the value should be encoded as binary, not string,
+ * but this may be necessary for compatibility with non-ideal systems.
+ */
+export class RawBinaryString {
+  /**
+   * Create a new RawBinaryString from an ArrayBufferView.
+   */
+  public constructor(public readonly rawBinaryValue: ArrayBufferView) {
+    if (!ArrayBuffer.isView(rawBinaryValue)) {
+      throw new TypeError("RawBinaryString: rawBinaryValue must be an ArrayBufferView");
+    }
+  }
+}

--- a/test/raw-strings.test.ts
+++ b/test/raw-strings.test.ts
@@ -37,125 +37,191 @@ describe("encode with RawBinaryString", () => {
     ]);
     assert.deepStrictEqual(actual, expected);
   });
-});
 
-describe("decode with rawBinaryStringValues specified", () => {
-  const options = { rawBinaryStringValues: true } satisfies DecoderOptions;
-
-  it("decodes string values as binary", () => {
-    const actual = decode(encode("foo"), options);
-    const expected = Uint8Array.from([0x66, 0x6f, 0x6f]);
+  it("encodes a RawBinaryString map key and value as a string", () => {
+    const actual = encode(
+      new Map([
+        [
+          new RawBinaryString(Uint8Array.from([0x6b, 0x65, 0x79])),
+          new RawBinaryString(Uint8Array.from([0x66, 0x6f, 0x6f])),
+        ],
+      ]),
+    );
+    const expected = encode({ key: "foo" });
     assert.deepStrictEqual(actual, expected);
   });
 
-  it("decodes invalid UTF-8 string values as binary", () => {
-    const encoded = Uint8Array.from([
-      217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50,
-      176, 184, 221, 66, 188, 171, 36, 135, 121,
-    ]);
-
-    const actual = decode(encoded, options);
-    assert.deepStrictEqual(actual, invalidUtf8String);
-  });
-
-  it("decodes map string keys as strings", () => {
-    const actual = decode(encode({ key: "foo" }), options);
-    const expected = { key: Uint8Array.from([0x66, 0x6f, 0x6f]) };
-    assert.deepStrictEqual(actual, expected);
-  });
-
-  it("ignores maxStrLength", () => {
-    const lengthLimitedOptions = { ...options, maxStrLength: 1 } satisfies DecoderOptions;
-
-    const actual = decode(encode("foo"), lengthLimitedOptions);
-    const expected = Uint8Array.from([0x66, 0x6f, 0x6f]);
-    assert.deepStrictEqual(actual, expected);
-  });
-
-  it("respects maxBinLength", () => {
-    const lengthLimitedOptions = { ...options, maxBinLength: 1 } satisfies DecoderOptions;
-
-    assert.throws(() => {
-      decode(encode("foo"), lengthLimitedOptions);
-    }, /max length exceeded/i);
-  });
-});
-
-describe("decode with rawBinaryStringKeys specified", () => {
-  const options = { rawBinaryStringKeys: true, useMap: true } satisfies DecoderOptions;
-
-  it("errors if useMap is not enabled", () => {
-    assert.throws(() => {
-      decode(encode({ key: "foo" }), { rawBinaryStringKeys: true });
-    }, new Error("rawBinaryStringKeys is only supported when useMap is true"));
-  });
-
-  it("decodes map string keys as binary", () => {
-    const actual = decode(encode({ key: "foo" }), options);
-    const expected = new Map([[Uint8Array.from([0x6b, 0x65, 0x79]), "foo"]]);
-    assert.deepStrictEqual(actual, expected);
-  });
-
-  it("decodes invalid UTF-8 string keys as binary", () => {
-    const encodedMap = Uint8Array.from([
-      129, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247,
-      19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121, 163, 97, 98, 99,
-    ]);
-    const actual = decode(encodedMap, options);
-    const expected = new Map([[invalidUtf8String, "abc"]]);
-    assert.deepStrictEqual(actual, expected);
-  });
-
-  it("decodes string values as strings", () => {
-    const actual = decode(encode("foo"), options);
-    const expected = "foo";
-    assert.deepStrictEqual(actual, expected);
-  });
-
-  it("ignores maxStrLength", () => {
-    const lengthLimitedOptions = { ...options, maxStrLength: 1 } satisfies DecoderOptions;
-
-    const actual = decode(encode({ foo: 1 }), lengthLimitedOptions);
-    const expected = new Map([[Uint8Array.from([0x66, 0x6f, 0x6f]), 1]]);
-    assert.deepStrictEqual(actual, expected);
-  });
-
-  it("respects maxBinLength", () => {
-    const lengthLimitedOptions = { ...options, maxBinLength: 1 } satisfies DecoderOptions;
-
-    assert.throws(() => {
-      decode(encode({ foo: 1 }), lengthLimitedOptions);
-    }, /max length exceeded/i);
-  });
-});
-
-describe("decode with rawBinaryStringKeys and rawBinaryStringValues", () => {
-  const options = { rawBinaryStringValues: true, rawBinaryStringKeys: true, useMap: true } satisfies DecoderOptions;
-
-  it("errors if useMap is not enabled", () => {
-    assert.throws(() => {
-      decode(encode({ key: "foo" }), { rawBinaryStringKeys: true, rawBinaryStringValues: true });
-    }, new Error("rawBinaryStringKeys is only supported when useMap is true"));
-  });
-
-  it("decodes map string keys and values as binary", () => {
-    const actual = decode(encode({ key: "foo" }), options);
-    const expected = new Map([[Uint8Array.from([0x6b, 0x65, 0x79]), Uint8Array.from([0x66, 0x6f, 0x6f])]]);
-    assert.deepStrictEqual(actual, expected);
-  });
-
-  it("decodes invalid UTF-8 string keys and values as binary", () => {
-    const invalidUtf8String = Uint8Array.from([
-      61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50, 176,
-      184, 221, 66, 188, 171, 36, 135, 121,
-    ]);
-    const encodedMap = Uint8Array.from([
+  it("encodes an invalid UTF-8 RawBinaryString map key and value as a string", () => {
+    const actual = encode(new Map([[new RawBinaryString(invalidUtf8String), new RawBinaryString(invalidUtf8String)]]));
+    const expected = Uint8Array.from([
       129, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247,
       19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84,
       121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121,
     ]);
-    const actual = decode(encodedMap, options);
-    const expected = new Map([[invalidUtf8String, invalidUtf8String]]);
     assert.deepStrictEqual(actual, expected);
   });
+});
+
+describe("decode with rawBinaryStringValues specified", () => {
+  for (const useRawBinaryStringClass of [true, false, undefined]) {
+    const options = { rawBinaryStringValues: true, useRawBinaryStringClass } satisfies DecoderOptions;
+
+    const prepareExpectedBytes = (expected: Uint8Array): Uint8Array | RawBinaryString => {
+      if (useRawBinaryStringClass) {
+        return new RawBinaryString(expected);
+      }
+      return expected;
+    };
+
+    context(`useRawBinaryStringClass=${useRawBinaryStringClass}`, () => {
+      it("decodes string values as binary", () => {
+        const actual = decode(encode("foo"), options);
+        const expected = prepareExpectedBytes(Uint8Array.from([0x66, 0x6f, 0x6f]));
+        assert.deepStrictEqual(actual, expected);
+      });
+
+      it("decodes invalid UTF-8 string values as binary", () => {
+        const encoded = Uint8Array.from([
+          217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19,
+          50, 176, 184, 221, 66, 188, 171, 36, 135, 121,
+        ]);
+
+        const actual = decode(encoded, options);
+        assert.deepStrictEqual(actual, prepareExpectedBytes(invalidUtf8String));
+      });
+
+      it("decodes map string keys as strings", () => {
+        const actual = decode(encode({ key: "foo" }), options);
+        const expected = { key: prepareExpectedBytes(Uint8Array.from([0x66, 0x6f, 0x6f])) };
+        assert.deepStrictEqual(actual, expected);
+      });
+
+      it("ignores maxStrLength", () => {
+        const lengthLimitedOptions = { ...options, maxStrLength: 1 } satisfies DecoderOptions;
+
+        const actual = decode(encode("foo"), lengthLimitedOptions);
+        const expected = prepareExpectedBytes(Uint8Array.from([0x66, 0x6f, 0x6f]));
+        assert.deepStrictEqual(actual, expected);
+      });
+
+      it("respects maxBinLength", () => {
+        const lengthLimitedOptions = { ...options, maxBinLength: 1 } satisfies DecoderOptions;
+
+        assert.throws(() => {
+          decode(encode("foo"), lengthLimitedOptions);
+        }, /max length exceeded/i);
+      });
+    });
+  }
+});
+
+describe("decode with rawBinaryStringKeys specified", () => {
+  for (const useRawBinaryStringClass of [true, false, undefined]) {
+    const options = { rawBinaryStringKeys: true, useMap: true, useRawBinaryStringClass } satisfies DecoderOptions;
+
+    const prepareExpectedBytes = (expected: Uint8Array): Uint8Array | RawBinaryString => {
+      if (useRawBinaryStringClass) {
+        return new RawBinaryString(expected);
+      }
+      return expected;
+    };
+
+    context(`useRawBinaryStringClass=${useRawBinaryStringClass}`, () => {
+      it("errors if useMap is not enabled", () => {
+        assert.throws(() => {
+          decode(encode({ key: "foo" }), { rawBinaryStringKeys: true, useRawBinaryStringClass });
+        }, new Error("rawBinaryStringKeys is only supported when useMap is true"));
+      });
+
+      it("decodes map string keys as binary", () => {
+        const actual = decode(encode({ key: "foo" }), options);
+        const expected = new Map([[prepareExpectedBytes(Uint8Array.from([0x6b, 0x65, 0x79])), "foo"]]);
+        assert.deepStrictEqual(actual, expected);
+      });
+
+      it("decodes invalid UTF-8 string keys as binary", () => {
+        const encodedMap = Uint8Array.from([
+          129, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174,
+          247, 19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121, 163, 97, 98, 99,
+        ]);
+        const actual = decode(encodedMap, options);
+        const expected = new Map([[prepareExpectedBytes(invalidUtf8String), "abc"]]);
+        assert.deepStrictEqual(actual, expected);
+      });
+
+      it("decodes string values as strings", () => {
+        const actual = decode(encode("foo"), options);
+        const expected = "foo";
+        assert.deepStrictEqual(actual, expected);
+      });
+
+      it("ignores maxStrLength", () => {
+        const lengthLimitedOptions = { ...options, maxStrLength: 1 } satisfies DecoderOptions;
+
+        const actual = decode(encode({ foo: 1 }), lengthLimitedOptions);
+        const expected = new Map([[prepareExpectedBytes(Uint8Array.from([0x66, 0x6f, 0x6f])), 1]]);
+        assert.deepStrictEqual(actual, expected);
+      });
+
+      it("respects maxBinLength", () => {
+        const lengthLimitedOptions = { ...options, maxBinLength: 1 } satisfies DecoderOptions;
+
+        assert.throws(() => {
+          decode(encode({ foo: 1 }), lengthLimitedOptions);
+        }, /max length exceeded/i);
+      });
+    });
+  }
+});
+
+describe("decode with rawBinaryStringKeys and rawBinaryStringValues", () => {
+  for (const useRawBinaryStringClass of [true, false, undefined]) {
+    const options = {
+      rawBinaryStringValues: true,
+      rawBinaryStringKeys: true,
+      useMap: true,
+      useRawBinaryStringClass,
+    } satisfies DecoderOptions;
+
+    const prepareExpectedBytes = (expected: Uint8Array): Uint8Array | RawBinaryString => {
+      if (useRawBinaryStringClass) {
+        return new RawBinaryString(expected);
+      }
+      return expected;
+    };
+
+    context(`useRawBinaryStringClass=${useRawBinaryStringClass}`, () => {
+      it("errors if useMap is not enabled", () => {
+        assert.throws(() => {
+          decode(encode({ key: "foo" }), {
+            rawBinaryStringKeys: true,
+            rawBinaryStringValues: true,
+            useRawBinaryStringClass,
+          });
+        }, new Error("rawBinaryStringKeys is only supported when useMap is true"));
+      });
+
+      it("decodes map string keys and values as binary", () => {
+        const actual = decode(encode({ key: "foo" }), options);
+        const expected = new Map([
+          [
+            prepareExpectedBytes(Uint8Array.from([0x6b, 0x65, 0x79])),
+            prepareExpectedBytes(Uint8Array.from([0x66, 0x6f, 0x6f])),
+          ],
+        ]);
+        assert.deepStrictEqual(actual, expected);
+      });
+
+      it("decodes invalid UTF-8 string keys and values as binary", () => {
+        const encodedMap = Uint8Array.from([
+          129, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174,
+          247, 19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116,
+          105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121,
+        ]);
+        const actual = decode(encodedMap, options);
+        const expected = new Map([[prepareExpectedBytes(invalidUtf8String), prepareExpectedBytes(invalidUtf8String)]]);
+        assert.deepStrictEqual(actual, expected);
+      });
+    });
+  }
 });

--- a/test/raw-strings.test.ts
+++ b/test/raw-strings.test.ts
@@ -1,6 +1,43 @@
 import assert from "assert";
-import { encode, decode } from "../src";
+import { encode, decode, RawBinaryString } from "../src";
 import type { DecoderOptions } from "../src";
+
+const invalidUtf8String = Uint8Array.from([
+  61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50, 176, 184,
+  221, 66, 188, 171, 36, 135, 121,
+]);
+
+describe("encode with RawBinaryString", () => {
+  it("encodes a RawBinaryString value as a string", () => {
+    const actual = encode(new RawBinaryString(Uint8Array.from([0x66, 0x6f, 0x6f])));
+    const expected = encode("foo");
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("encodes an invalid UTF-8 RawBinaryString value as a string", () => {
+    const actual = encode(new RawBinaryString(invalidUtf8String));
+    const expected = Uint8Array.from([
+      217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50,
+      176, 184, 221, 66, 188, 171, 36, 135, 121,
+    ]);
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("encodes a RawBinaryString map key as a string", () => {
+    const actual = encode(new Map([[new RawBinaryString(Uint8Array.from([0x6b, 0x65, 0x79])), "foo"]]));
+    const expected = encode({ key: "foo" });
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  it("encodes an invalid UTF-8 RawBinaryString map key as a string", () => {
+    const actual = encode(new Map([[new RawBinaryString(invalidUtf8String), "abc"]]));
+    const expected = Uint8Array.from([
+      129, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247,
+      19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121, 163, 97, 98, 99,
+    ]);
+    assert.deepStrictEqual(actual, expected);
+  });
+});
 
 describe("decode with rawBinaryStringValues specified", () => {
   const options = { rawBinaryStringValues: true } satisfies DecoderOptions;
@@ -12,12 +49,8 @@ describe("decode with rawBinaryStringValues specified", () => {
   });
 
   it("decodes invalid UTF-8 string values as binary", () => {
-    const invalidUtf8String = Uint8Array.from([
-      61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50, 176,
-      184, 221, 66, 188, 171, 36, 135, 121,
-    ]);
     const encoded = Uint8Array.from([
-      196, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50,
+      217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50,
       176, 184, 221, 66, 188, 171, 36, 135, 121,
     ]);
 
@@ -64,10 +97,6 @@ describe("decode with rawBinaryStringKeys specified", () => {
   });
 
   it("decodes invalid UTF-8 string keys as binary", () => {
-    const invalidUtf8String = Uint8Array.from([
-      61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247, 19, 50, 176,
-      184, 221, 66, 188, 171, 36, 135, 121,
-    ]);
     const encodedMap = Uint8Array.from([
       129, 217, 32, 61, 180, 118, 220, 39, 166, 43, 68, 219, 116, 105, 84, 121, 46, 122, 136, 233, 221, 15, 174, 247,
       19, 50, 176, 184, 221, 66, 188, 171, 36, 135, 121, 163, 97, 98, 99,


### PR DESCRIPTION
#3 and #5 added support for decoding raw binary strings, i.e. leaving the value a a byte array instead of decoding into a string object.

This PR does the same for encoding -- you can now encode a byte array as a string. To do so, create an instance of the new `RawBinaryString` class that wraps your byte array. This type will encode the byte array contents as a string type.

These operations are useful when you must comply with a legacy protocol that uses the string family for values that can contain invalid UTF-8 sequences.

Additionally, during decoding, you can specify the `useRawBinaryStringClass` option for raw binary strings to be decoded as the new `RawBinaryString` class. With this, it's now possible to do a complete round-trip decoding and encoding of an object using raw binary strings.